### PR TITLE
Update actions/cache

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-ruby@v1
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
https://github.com/actions/cache/discussions/1510

2025年2月1日以降順次v2以下は廃止になるため
